### PR TITLE
Logger: Try to use user supplied global log callback when no specific logger is set

### DIFF
--- a/src/common/src/logger.c
+++ b/src/common/src/logger.c
@@ -23,6 +23,7 @@
 #include "cdi_core_api.h"
 #include "cdi_os_api.h"
 #include "singly_linked_list_api.h"
+#include "internal.h"
 
 //*********************************************************************************************************************
 //***************************************** START OF DEFINITIONS AND TYPES ********************************************
@@ -860,6 +861,10 @@ void CdiLogger(CdiLogHandle handle, CdiLogComponent component, CdiLogLevel log_l
                int line_number, const char* format_str, ...)
 {
     if (NULL == handle) {
+        handle = cdi_global_context.global_log_handle;
+    }
+
+    if (NULL == handle) {
         handle = stdout_log_handle;
     }
 
@@ -883,6 +888,10 @@ void CdiLogger(CdiLogHandle handle, CdiLogComponent component, CdiLogLevel log_l
 void CdiLoggerMultilineBegin(CdiLogHandle log_handle, CdiLogComponent component, CdiLogLevel log_level,
                              const char* function_name_str, int line_number, CdiLogMultilineState* state_ptr)
 {
+    if (NULL == log_handle) {
+        log_handle = cdi_global_context.global_log_handle;
+    }
+
     if (NULL == log_handle) {
         log_handle = stdout_log_handle;
     }


### PR DESCRIPTION
Sometimes log output from inside the CDI SDK doesn't go through the user supplied global log callback (eg. most things logged via CDI_LOG_THREAD). The logger then falls back to logging the lines in question through stdout.

This is a problem because stdout might not exist. This applies to all Windows programs linked against the Windows subsystem (i.e. windowed apps that don't explicitly open a console window), and can also be an issue under Linux if eg. after a fork() you close the standard io handles to detach from the console.

In case there's no stdout the stdout logger fails and then tries to log the failure to stdout again, resulting in an infinite recursion and eventually a stack overflow. This is a 100% reproducible crash under Windows - all you need to do is open a Rx connection in a non-console app.

This PR fixes the issue by letting all log items that haven't a specific logger set go through the global logger (if specified) before falling back to stdout. This is the behavior a users would IMO expect anyway - if I set a global log callback I'd like to have everything go through it.

I know this PR might raise some concerns - no idea if the added dependency to internal.h satisfies your idea of good structure, and first of all it requires the user log callback to be completely thread safe. But this is a requirement that's reasonable to have, and might be mitigated by a possible fix for Issue #21.
