### PR TITLE
Add missed third-party dependencies  for ubuntu

### DIFF
--- a/INSTALL_GUIDE_LINUX.md
+++ b/INSTALL_GUIDE_LINUX.md
@@ -143,7 +143,7 @@ Installation of dependent packages is required before building the AWS CDI SDK a
 - Ubuntu:
 
     ```bash
-    sudo apt-get install –y libncurses-dev autoconf automake libtool libnl-3-dev
+    sudo apt-get install –y libncurses-dev autoconf automake libtool libnl-3-dev g++ zlib1g-dev libssl-dev libcurl4-openssl-dev doxygen
     ```
 
 ## Install CMake


### PR DESCRIPTION
Fix for compile time errors:

1. Compiling the CXX compiler identification source file "CMakeCXXCompilerId.cpp" failed.
Compiler: CMAKE_CXX_COMPILER-NOTFOUND 

2. Could not find zlib 

3. Could not find openssl

4. Could not find curl

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
