### PR TITLE
test_minimal: fix default for use_efa

### DIFF
--- a/src/test_common/include/test_common.h
+++ b/src/test_common/include/test_common.h
@@ -40,6 +40,9 @@ typedef struct CommandLineState* CommandLineHandle;
 /// @brief Default payload size.
 #define DEFAULT_PAYLOAD_SIZE                (5184000)
 
+/// @brief Default EFA usage
+#define DEFAULT_USE_EFA                     1
+
 /// @brief Number of elements in a static array.
 #define ARRAY_ELEMENT_COUNT(thisarray) ((int)(sizeof(thisarray)/sizeof(thisarray[0])))
 

--- a/src/test_minimal/test_minimal_receiver.c
+++ b/src/test_minimal/test_minimal_receiver.c
@@ -226,7 +226,8 @@ int main(int argc, const char** argv)
     TestConnectionInfo con_info = {
         .test_settings.protocol_type = DEFAULT_PROTOCOL_TYPE,
         .test_settings.num_transactions = DEFAULT_NUM_TRANSACTIONS,
-        .test_settings.payload_size = DEFAULT_PAYLOAD_SIZE
+        .test_settings.payload_size = DEFAULT_PAYLOAD_SIZE,
+        .test_settings.use_efa = DEFAULT_USE_EFA,
     };
 
     // Parse command line.

--- a/src/test_minimal/test_minimal_transmitter.c
+++ b/src/test_minimal/test_minimal_transmitter.c
@@ -377,7 +377,8 @@ int main(int argc, const char** argv)
         .test_settings.payload_size = DEFAULT_PAYLOAD_SIZE,
         .test_settings.rate_numerator = DEFAULT_RATE_NUMERATOR,
         .test_settings.rate_denominator = DEFAULT_RATE_DENOMINATOR,
-        .test_settings.tx_timeout = DEFAULT_TX_TIMEOUT
+        .test_settings.tx_timeout = DEFAULT_TX_TIMEOUT,
+        .test_settings.use_efa = DEFAULT_USE_EFA,
     };
 
     // Parse command line.


### PR DESCRIPTION
The default value for the --use_efa option of the minimal examples
is documented as true, however it was left wero-initialized.

Fix by initializing to the correct, documented value.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
