### PR TITLE
INSTALL_GUIDE_LINUX.md - added Rocky Linux 8 section

### DIFF
--- a/INSTALL_GUIDE_LINUX.md
+++ b/INSTALL_GUIDE_LINUX.md
@@ -57,6 +57,14 @@ Installation of dependent packages is required before building the AWS CDI SDK:
     sudo yum -y install gcc-c++ make cmake3 curl-devel openssl-devel autoconf automake libtool doxygen ncurses-devel unzip
     ```
 
+- Rocky Linux 8:
+
+  ```bash
+  sudo dnf update -y
+  sudo dnf config-manager --set-enabled powertools
+  sudo dnf -y install gcc-c++ make cmake3 curl-devel openssl-devel autoconf automake libtool doxygen ncurses-devel unzip
+  ```
+
 - Ubuntu:
 
     ```bash


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

Added RL 8 section for install dependencies as EFA driver v1.20 now supports Rocky Linux 8, which is used in post-production/Visual Effects industry.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
