### PR TITLE
Update cdi_core_api.h

### DIFF
--- a/include/cdi_core_api.h
+++ b/include/cdi_core_api.h
@@ -119,10 +119,10 @@
 
 /// @brief Define to limit the max number of payloads that can arrive out of order and be put back in order. Value must
 /// be a power of 2.
-#define CDI_MAX_RX_PAYLOAD_OUT_OF_ORDER_BUFFER          (4096)
+#define CDI_MAX_RX_PAYLOAD_OUT_OF_ORDER_BUFFER          (8192)
 
 /// @brief Define to limit the max number packets of that can arrive out of order and be put back in order.
-#define CDI_MAX_RX_PACKET_OUT_OF_ORDER_WINDOW           (4000)
+#define CDI_MAX_RX_PACKET_OUT_OF_ORDER_WINDOW           (5000)
 
 /// @brief Maximum connection name string length.
 #define CDI_MAX_CONNECTION_NAME_STRING_LENGTH           (128)


### PR DESCRIPTION
*Issue #, if available:*

Current default values are not sufficient to receive 4K RGB 4:4:4 12 bit

*Description of changes:*

/// @brief Define to limit the max number of payloads that can arrive out of order and be put back in order. Value must
/// be a power of 2.
#define CDI_MAX_RX_PAYLOAD_OUT_OF_ORDER_BUFFER          (8192)

CDI_MAX_RX_PAYLOAD_OUT_OF_ORDER_BUFFER must be increased but (it's limited to power of 2 by implementation), so increase from 4096 to 8192

/// @brief Define to limit the max number packets of that can arrive out of order and be put back in order.
#define CDI_MAX_RX_PACKET_OUT_OF_ORDER_WINDOW           (5000)

CDI_MAX_RX_PACKET_OUT_OF_ORDER_WINDOW of 4000 is not sufficient to receive 4K RGB 4:4:4 12 bit, but 5000 works well

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
