### PR TITLE
Add IAM Policy editor warning to INSTALL_GUIDE_LINUX.md

### DIFF
--- a/INSTALL_GUIDE_LINUX.md
+++ b/INSTALL_GUIDE_LINUX.md
@@ -158,8 +158,8 @@ AWS CLI is required to setup configuration files for AWS CloudWatch.
 1. Create an IAM User with CloudWatch and performance metrics permissions.
     - Navigate to the [AWS console IAM Policies](https://console.aws.amazon.com/iam/home#/policies)
         - Select **Create policy** and then select **JSON**.
-        - The minimum security IAM policy is below:
-
+        - The minimum security IAM policy is below.
+        - Note: You may receive an IAM Policy editor warning such as: ```Errors: Invalid Action``` on the line with ```"mediaconnect:PutMetricGroups"```, which can be safely ignored.<p></p>     
         ```JSON
         {
             "Version": "2012-10-17",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Warn ahead of time that the IAM Policy editor will state ```Errors: Invalid Action``` on the line with ```"mediaconnect:PutMetricGroups"```, which can be safely ignored.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
