### PR TITLE
Merge bugfix changes for Windows variant

### DIFF
--- a/INSTALL_GUIDE_LINUX.md
+++ b/INSTALL_GUIDE_LINUX.md
@@ -158,7 +158,7 @@ AWS CLI is required to setup configuration files for AWS CloudWatch.
 1. Create an IAM User with CloudWatch and performance metrics permissions.
     - Navigate to the [AWS console IAM Policies](https://console.aws.amazon.com/iam/home#/policies)
         - Select **Create policy** and then select **JSON**.
-        - The minimum security IAM policy is below.
+        - The minimum security IAM policy is below:
         - Note: You may receive an IAM Policy editor warning such as: ```Errors: Invalid Action``` on the line with ```"mediaconnect:PutMetricGroups"```, which can be safely ignored.
 
         ```JSON

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -4,6 +4,23 @@ This file is part of the AWS CDI-SDK, licensed under the BSD 2-Clause "Simplifie
 License details at: https://github.com/aws/aws-cdi-sdk/blob/mainline/LICENSE
 -------------------------------------------------------------------------------------------
 
+CDI (Cloud Digital Interface) SDK Version x.x.x - ??/??/????
+
+What's New
+------------
+
+* TBD
+
+Bug Fixes
+------------
+
+* Windows EFA driver does not support changing the RNR (Remote Not Ready) configuration, so no need to attempt
+  to change its value to support versions of libfabric later than libfabric 1.9.x. See changes in src/cdi/adapter_efa.c
+* Ensure that WriteLineToLog() does not use invalid handle when writing to stdout. Problem was seen on the Windows
+  variant. See changes in in src/common/src/logger.c.
+* For the windows variant when using the CdiOsSocketReadFrom() API if the socket is not connected, ensure that there
+  are no packet bytes returned to the caller. See changes in src/common/src/os_windows.c
+
 CDI (Cloud Digital Interface) SDK Version 3.0.2 - 02/02/2024
 
 What's New

--- a/src/cdi/adapter_efa.c
+++ b/src/cdi/adapter_efa.c
@@ -434,6 +434,8 @@ static CdiReturnStatus LibFabricEndpointOpen(EfaEndpointState* endpoint_ptr)
         CHECK_LIBFABRIC_RC(fi_endpoint, ret);
     }
 
+    // Windows does not support this option. It is configured by default as the previous 1.9.x version of libfabric.
+#ifndef _WIN32
     // Set RNR (Remote Not Ready) retry counter to match libfabric 1.9.x setting, which forced the EFA hardware to
     // continuously retry to send packets even if the remote is not ready. If this is not done, newer versions of
     // libfabric will cause FI_EAGAIN to be returned from fi_sendmsg() whenever resources are not available on the
@@ -443,6 +445,7 @@ static CdiReturnStatus LibFabricEndpointOpen(EfaEndpointState* endpoint_ptr)
         int ret = fi_setopt(&endpoint_ptr->endpoint_ptr->fid, FI_OPT_ENDPOINT, FI_OPT_EFA_RNR_RETRY, &rnr_retry, sizeof(rnr_retry));
         CHECK_LIBFABRIC_RC(fi_setopt, ret);
     }
+#endif
 
     // Bind address vector.
     if (kCdiStatusOk == rs) {

--- a/src/common/src/logger.c
+++ b/src/common/src/logger.c
@@ -621,6 +621,9 @@ static void WriteLineToLog(CdiLogHandle handle, CdiLogLevel log_level, bool mult
         file_handle = CDI_STDOUT;
     } else {
         file_handle = handle->file_data_ptr->file_handle;
+        if (kLogMethodStdout == handle->log_method && NULL == file_handle) {
+            return; // Ensure we don't output to an invalid handle.
+        }
     }
 
     char final_log_str[CDI_MAX_LOG_STRING_LENGTH];

--- a/src/common/src/os_windows.c
+++ b/src/common/src/os_windows.c
@@ -1297,6 +1297,7 @@ bool CdiOsSocketReadFrom(CdiSocket socket_handle, void* buffer_ptr, int* byte_co
             // will be returned.
             if (WSAECONNRESET == code) {
                 ret = true;
+                *byte_count_ptr = 0; // Ensure zero bytes read are returned.
             } else {
                 ERROR_MESSAGE("WSARecvFrom failed. Code[%d]", code);
             }


### PR DESCRIPTION
* Windows EFA driver does not support changing the RNR (Remote Not Ready) configuration, so no need to attempt
  to change its value to support versions of libfabric later than libfabric 1.9.x. See changes in src/cdi/adapter_efa.c
* Ensure that WriteLineToLog() does not use invalid handle when writing to stdout. Problem was seen on the Windows
  variant. See changes in in src/common/src/logger.c.
* For the windows variant when using the CdiOsSocketReadFrom() API if the socket is not connected, ensure that there
  are no packet bytes returned to the caller. See changes in src/common/src/os_windows.c