### PR TITLE
Problem with AVM Audio MakeBaselineAudioConfiguration(). Fixed invalid warning in cdi_test Rx.

### DIFF
--- a/src/cdi/baseline_profiles_1_00.c
+++ b/src/cdi/baseline_profiles_1_00.c
@@ -392,7 +392,7 @@ static bool MakeBaselineAudioConfiguration(const CdiAvmBaselineConfigCommon* bas
     if ('\0' != audio_config_ptr->language[0]) {
         char language_str[sizeof(audio_config_ptr->language) + 1] = { '\0' };
         memcpy(language_str, audio_config_ptr->language, sizeof(audio_config_ptr->language));
-        int pos = snprintf(language_param_str, sizeof(language_param_str), " language=%s;", audio_config_ptr->language);
+        int pos = snprintf(language_param_str, sizeof(language_param_str), " language=%s;", language_str);
         if ((int)sizeof(language_param_str) <= pos) {
             CDI_LOG_THREAD(kLogError, "audio language parameter could not be formatted");
             ret = false;

--- a/src/cdi/baseline_profiles_2_00.c
+++ b/src/cdi/baseline_profiles_2_00.c
@@ -355,7 +355,7 @@ static bool MakeBaselineAudioConfiguration(const CdiAvmBaselineConfigCommon* bas
     if ('\0' != audio_config_ptr->language[0]) {
         char language_str[sizeof(audio_config_ptr->language) + 1] = { '\0' };
         memcpy(language_str, audio_config_ptr->language, sizeof(audio_config_ptr->language));
-        int pos = snprintf(language_param_str, sizeof(language_param_str), " language=%s;", audio_config_ptr->language);
+        int pos = snprintf(language_param_str, sizeof(language_param_str), " language=%s;", language_str);
         if ((int)sizeof(language_param_str) <= pos) {
             CDI_LOG_THREAD(kLogError, "audio language parameter could not be formatted");
             ret = false;

--- a/src/test/test_receiver.c
+++ b/src/test/test_receiver.c
@@ -1047,9 +1047,11 @@ static void TestAvmRxCallback(const CdiAvmRxCbData* cb_data_ptr)
         TestRxProcessCoreCallbackData(&cb_data_ptr->core_cb_data, stream_index);
     }
 
-    // Perform any cleanup operation on this data including writing the data to the destination FIFO and incrementing
-    // the payload count.
-    RxCoreCallbackCleanup(&cb_data_ptr->core_cb_data, &cb_data_ptr->sgl, stream_index);
+    if (-1 != stream_index) {
+        // Perform any cleanup operation on this data including writing the data to the destination FIFO and incrementing
+        // the payload count.
+        RxCoreCallbackCleanup(&cb_data_ptr->core_cb_data, &cb_data_ptr->sgl, stream_index);
+    }
 }
 
 //*********************************************************************************************************************


### PR DESCRIPTION
* Both AVM baseline profiles were using the wrong language string when creating the AVM string. The string that was being used is the original string, which is not NULL terminated. This was causing the function to fail in OSB Studio (windows).
* cdi_test as a receiver generates invalid error messages with an invalid stream identifier if an unexpected stream is received. RxCoreCallbackCleanup() should not be invoked in this case.