### PR TITLE
RPATH problem / NDI fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,7 @@ $(libfabric_api) : $(libfabric_config_h) $(objs.libfabric_api) $(libfabric) | $(
 	$(Q)$(CC) -shared -o $@ -Wl,-z,defs,-soname=$(basename $(notdir $@)) \
 		$(objs.libfabric_api) -L$(build_dir.lib) \
 		-ldl -lrt $(EXTRA_CC_LIBS) -lm $(EXTRA_LD_LIBS) -lpthread -lc \
-		$(ASAN_LIBS)
+		$(ASAN_LIBS) -Wl,-rpath,\$$ORIGIN:\$$ORIGIN/lib
 	$(Q)ln -fs $@ $(basename $@)
 	$(Q)ln -fs $@ $(basename $(basename $@))
 
@@ -491,7 +491,7 @@ $(libfabric_api_new) : $(libfabric_new_config_h) $(objs.libfabric_api_new) $(lib
 	$(Q)$(CC) -shared -o $@ -Wl,-z,defs,-soname=$(basename $(notdir $@)) \
 		$(objs.libfabric_api_new) -L$(build_dir.lib) \
 		-ldl -lrt $(EXTRA_CC_LIBS) -lm $(EXTRA_LD_LIBS) -lpthread -lc \
-		$(ASAN_LIBS)
+		$(ASAN_LIBS) -Wl,-rpath,\$$ORIGIN:\$$ORIGIN/lib
 	$(Q)ln -fs $@ $(basename $@)
 	$(Q)ln -fs $@ $(basename $(basename $@))
 

--- a/src/ndi_test/ndi_test.h
+++ b/src/ndi_test/ndi_test.h
@@ -114,6 +114,7 @@ struct TestConnectionInfo {
     CdiPtpTimestamp connection_start_time;
     uint64_t total_audio_samples; ///< Total number of audio samples processed.
     uint32_t total_video_frames; ///< Total number of video frames processed.
+    uint64_t total_video_duration_ns; ///< Total video duration in nanoseconds.
 
     double cdi_video_period_fraction_ns; ///< Video CDI period fractional portion in nS.
     double cdi_audio_period_fraction_ns; ///< Audio CDI period fractional portion in uS.

--- a/src/ndi_test/ndi_to_cdi.c
+++ b/src/ndi_test/ndi_to_cdi.c
@@ -149,22 +149,24 @@ static CdiReturnStatus SendAvmPayload(FrameData* frame_data_ptr, CdiSgList* sgl_
 static CdiPtpTimestamp GetPtpTimestamp(TestConnectionInfo* con_info_ptr, const FrameData* frame_data_ptr)
 {
     CdiPtpTimestamp timestamp;
-    uint64_t duration_ns;
+    uint64_t duration_ns = 0;
 
-    if (frame_data_ptr->frame_type == kNdiVideo || frame_data_ptr->frame_type == kNdiMetaData) {
-        // Video and metadata uses the total number of frames processed to determine the timestamp.
+    if (frame_data_ptr->frame_type == kNdiVideo) {
+        // Video uses the total number of frames processed to determine the timestamp.
         duration_ns = (con_info_ptr->total_video_frames * (uint64_t)CDI_NANOSECONDS_PER_SECOND *
                       frame_data_ptr->data.video_frame.frame_rate_D) / frame_data_ptr->data.video_frame.frame_rate_N;
-        if (frame_data_ptr->frame_type == kNdiVideo) {
-            // For video, increment the video frame counter used above to calculate timestamps.
-            con_info_ptr->total_video_frames++;
-        }
+        // Increment the video frame counter used above to calculate timestamps.
+        con_info_ptr->total_video_frames++;
+        con_info_ptr->total_video_duration_ns = duration_ns;
     } else if (frame_data_ptr->frame_type == kNdiAudio) {
         // Audio uses the total number of audio samples processed to determine the timestamp.
         duration_ns = con_info_ptr->total_audio_samples * CDI_NANOSECONDS_PER_SECOND /
                       frame_data_ptr->data.audio_frame.sample_rate;
         // Now, add the number of audio samples in this frame to the running total used above to calculate timestamps.
         con_info_ptr->total_audio_samples += frame_data_ptr->data.audio_frame.no_samples;
+    } else if (frame_data_ptr->frame_type == kNdiMetaData) {
+        // Use current total video frame duration for metadata.
+        duration_ns = con_info_ptr->total_video_duration_ns;
     }
 
     // Add the existing start time nanoseconds to the duration so the logic below calculates the correct seconds and
@@ -335,7 +337,7 @@ CdiReturnStatus NdiReceiverToCdiTransmitter(TestConnectionInfo* con_info_ptr)
             }
             LogTimestamps(con_info_ptr, frame_data_ptr, &cdi_timestamp);
             TestLogAVMChanges(stream_identifier, sgl.total_data_size, &avm_config, &baseline_config,
-                              &con_info_ptr->last_baseline_config[baseline_config.payload_type]);
+                              &con_info_ptr->last_baseline_config[baseline_config.payload_type-1]); // Index is 1 based.
 
             // Setup payload start time.
             con_info_ptr->payload_start_time = CdiOsGetMicroseconds();

--- a/src/ndi_test/ndi_wrapper.c
+++ b/src/ndi_test/ndi_wrapper.c
@@ -192,11 +192,13 @@ static bool CdiToNdiAudioConversion(const uint8_t* cdi_audio_ptr, int cdi_audio_
 {
     // Validate CDI audio contains the correct number of 24-bit audio samples.
     assert(cdi_audio_size <= num_channels * num_samples_per_channel * CDI_BYTES_PER_AUDIO_SAMPLE);
+    (void)cdi_audio_size; // suppress release build errors
 
     int ndi_audio_size = num_channels * num_samples_per_channel * sizeof(float);
     // Validate that the NDI buffer is large enough to hold the NDI float audio samples.
     int ndi_audio_buffer_size = *ndi_size_ptr;
     assert(ndi_audio_size <= ndi_audio_buffer_size);
+    (void)ndi_audio_buffer_size; // suppress release build errors
 
     // Validate that pointers are non-NULL.
     assert(cdi_audio_ptr && ndi_audio_ptr);


### PR DESCRIPTION
*Description of changes:*

- Added RPATH to libfabric_api libraries. On Amazon Linux 2023, libfabric.so was not found without setting LD_LIBRARY_PATH. This resolved the problem.
- The NDI->CDI test application was not correctly handling timestamps for NDI ancillary data. They don't exist, so must use the most recent video frame's timestamp when generating a CDI timestamp.
- Fixed a few release build errors for the Linux variant in ndi_wrapper.c.
