### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ mainline ]
 
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   build-documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,6 +3,9 @@ on:
     # runs every day at 1am
     - cron: "0 1 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   # This workflow contains a single job called "traffic"
   traffic:

--- a/.github/workflows/workflow_manual.yml
+++ b/.github/workflows/workflow_manual.yml
@@ -1,5 +1,8 @@
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   # This workflow contains a single job called "traffic"
   traffic:


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.